### PR TITLE
フォントの変更

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -6,8 +6,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-quantico);
-  --font-mono: var(--font-quantico);
+  --font-sans: var(--font-play);
+  --font-mono: var(--font-play);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next';
-import { Quantico } from 'next/font/google';
+import { Play } from 'next/font/google';
 
 import AuthProvider from '@/providers/Auth';
 
 import './globals.css';
 
-const quantico = Quantico({
-  variable: '--font-quantico',
+const play = Play({
+  variable: '--font-play',
   subsets: ['latin'],
   weight: ['400'],
 });
@@ -26,7 +26,7 @@ export default function RootLayout({
       <body
         className={`
           antialiased
-          ${quantico.variable}
+          ${play.variable}
           font-sans
         `}
       >


### PR DESCRIPTION
# issue
- #167 

# description
[Quantico](https://fonts.google.com/specimen/Quantico)は(と[の見分けがつかないため、フォント[Play](https://fonts.google.com/specimen/Play)に変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- スタイル
  - アプリ全体のフォントをQuanticoからPlayへ変更。本文および等幅に適用し、可読性と一貫性を向上。
  - レイアウト構造は維持しつつ、フォントの読み込みと適用を更新して安定したタイポグラフィを提供。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->